### PR TITLE
Ignore application that skews visualizations

### DIFF
--- a/USDA_data.py
+++ b/USDA_data.py
@@ -10,6 +10,9 @@ df = pd.read_excel('USDA_data.xlsx')
 # Clean data by removing baselining and duplicates
 df = df[df['Usage'] != 'Baselining'].drop_duplicates()
 
+# Ignore application that skews visualizations
+df = df[df['Name'] != 'Adobe Reader and Acrobat Manager']
+
 # Indicate all columns where tag data may be located
 id_columns = [
     'Asset - Custom Tags - Copy.2', 


### PR DESCRIPTION
- Filters `Adobe Reader and Acrobat Manager` from the dataset.
- This application skews visualizations and does not offer significant results, so we can safely ignore it.